### PR TITLE
[Auto] security(learn): add .limit(500) to video_progress GET query

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -299,7 +299,7 @@ These features tie everything together into a coherent product. Without them, ev
 
 ### Security
 - [ ] Truncate visa-tracker inputs — add `.slice(0,100)` to employer/occupation and ISO-date check on started_at in app/api/visa-tracker/route.ts:45-48 [security]
-- [ ] Add `.limit(500)` to video_progress select in app/api/learn/progress/route.ts:55 — grows unbounded per user [security]
+- [x] Add `.limit(500)` to video_progress select in app/api/learn/progress/route.ts:55 — grows unbounded per user [security] — 2026-04-21
 - [ ] Cap `req.json()` payload at 50KB before interpolating into GPT-4o prompt in app/api/analytics/ai-insights/route.ts:24 [security]
 - [ ] Add `checkEndpointRateLimit(admin.id, 'analytics/ai-insights')` to app/api/analytics/ai-insights/route.ts — GPT-4o call is unmetered [security]
 

--- a/app/api/learn/progress/route.ts
+++ b/app/api/learn/progress/route.ts
@@ -52,7 +52,7 @@ export async function GET(req: NextRequest) {
     .select('video_id, quiz_score, quiz_taken, completed')
     .eq('user_id', user.id);
   if (channel) query = query.eq('channel_name', channel);
-  const { data } = await query;
+  const { data } = await query.limit(500);
 
   return NextResponse.json({ progress: data ?? [] });
 }

--- a/daily-agent-log.md
+++ b/daily-agent-log.md
@@ -1,0 +1,40 @@
+# Daily Agent Log — 2026-04-21
+
+## Task completed
+**security(learn): add `.limit(500)` to `video_progress` GET query**
+
+Selected from TODO.md Daily Analyst Findings (2026-04-21):
+> "Add `.limit(500)` to video_progress select in app/api/learn/progress/route.ts:55 — grows unbounded per user [security]"
+
+### What was changed
+- `app/api/learn/progress/route.ts` line 55 — chained `.limit(500)` onto the `video_progress`
+  Supabase query in the GET handler. Without this, the query returned every row for a user
+  with no upper bound, risking large data transfers and Supabase read costs.
+- `TODO.md` — item marked `[x]` with date `2026-04-21`.
+
+### Quality gate results
+- TypeScript: 0 errors (`npx tsc --noEmit`)
+- Audit: 0 vulnerabilities (`npm audit --audit-level=moderate`)
+- Tests: 41/41 passed (`npx vitest run` — 8 test files)
+- Build: clean (`npm run build` — 276 routes compiled)
+
+### Branch
+`auto/2026-04-21/add-limit-video-progress-query` — pushed to origin.
+
+## Why PR creation failed
+`gh pr create` returns HTTP 403: **"GitHub Actions is not permitted to create or approve pull requests."**
+
+This is a repository-level setting:
+**Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests" (currently OFF)**
+
+### Action required by human
+Enable the setting above, then run:
+```bash
+gh pr create \
+  --head auto/2026-04-21/add-limit-video-progress-query \
+  --base main \
+  --title "[Auto] security(learn): add .limit(500) to video_progress GET query" \
+  --body "One-line security fix: cap unbounded video_progress query. See commit message for details."
+```
+Or open the PR manually at:
+https://github.com/Sheng-wei-Tsai/henrys-blog/compare/auto/2026-04-21/add-limit-video-progress-query


### PR DESCRIPTION
## What
Adds `.limit(500)` to the unbounded Supabase query in the video progress GET route to prevent potential abuse from returning all rows.

## Why
TODO.md Priority 0 security item — unbounded Supabase queries without `.limit()` can be abused to dump large datasets.

## Files changed
- `app/api/learn/progress/route.ts` — added `.limit(500)` to the `video_progress` query

## Quality gate
- TypeScript: 0 errors ✅
- Tests: all pass ✅
- Build: clean ✅
- Audit: 0 vulnerabilities ✅

## How to review
Check that the limit is sensible (500 rows is generous for a user's watch history). Verify the query chain is correct for the existing filter pattern.

---
*Opened by TechPath Daily Developer (Sonnet 4.6)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line API hardening change; main behavioral impact is that users with >500 `video_progress` rows will receive truncated results until pagination is added.
> 
> **Overview**
> Adds an explicit `.limit(500)` to the `/api/learn/progress` `GET` Supabase query to prevent unbounded per-user reads and reduce potential data-dump/cost risk.
> 
> Marks the corresponding Daily Analyst TODO item as completed and adds a `daily-agent-log.md` entry documenting the change and local quality-gate results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af347cc7a111f793406db8a7ca2fd89ec113b535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->