### PR TITLE
security(api): truncate AI prompt inputs + validate UUID route params

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -18,9 +18,12 @@ async function requireAdmin(sb: Awaited<ReturnType<typeof adminSupabase>>) {
   return profile?.role === 'admin' ? user : null;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // PATCH /api/admin/users/[id] — update role
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  if (!UUID_RE.test(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   const sb = await adminSupabase();
   const admin = await requireAdmin(sb);
   if (!admin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
@@ -45,6 +48,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 // DELETE /api/admin/users/[id] — ban: delete all comments, set role to banned
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  if (!UUID_RE.test(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   const sb = await adminSupabase();
   const admin = await requireAdmin(sb);
   if (!admin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });

--- a/app/api/comments/[id]/route.ts
+++ b/app/api/comments/[id]/route.ts
@@ -11,8 +11,11 @@ async function serverSupabase() {
   );
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  if (!UUID_RE.test(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   const sb = await serverSupabase();
   const { data: { user } } = await sb.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -38,6 +41,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  if (!UUID_RE.test(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   const sb = await serverSupabase();
   const { data: { user } } = await sb.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/api/cover-letter/route.ts
+++ b/app/api/cover-letter/route.ts
@@ -44,8 +44,8 @@ export async function POST(req: NextRequest) {
 
   const userPrompt = `Write a cover letter for this role.
 
-JOB TITLE: ${jobTitle}
-COMPANY: ${company}
+JOB TITLE: ${jobTitle.slice(0, 200)}
+COMPANY: ${company.slice(0, 200)}
 
 JOB DESCRIPTION:
 ${jobDescription.slice(0, 3000)}

--- a/app/api/interview/chat/route.ts
+++ b/app/api/interview/chat/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: NextRequest) {
       model: 'gpt-4o-mini',
       messages: [
         { role: 'system', content: systemContent },
-        ...messages.slice(-10),
+        ...messages.slice(-10).map(m => ({ ...m, content: String(m.content).slice(0, 2000) })),
       ],
       max_tokens: 200,
       stream: true,

--- a/app/au-insights/Sponsorship.tsx
+++ b/app/au-insights/Sponsorship.tsx
@@ -49,9 +49,9 @@ export default function Sponsorship() {
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: '0.8rem', marginBottom: '1.5rem' }}>
         {[
           { label: 'TSS/482 visa grants (FY2023)', value: '98,980', color: 'var(--terracotta)' },
-          { label: 'Top occupation (2023)', value: 'Software Dev', color: '#7c3aed' },
-          { label: 'Applications growth (2024–25)', value: '+53%', color: '#10b981' },
-          { label: 'ICT share of 482 grants', value: '~12%', color: '#0369a1' },
+          { label: 'Top occupation (2023)', value: 'Software Dev', color: 'var(--gold)' },
+          { label: 'Applications growth (2024–25)', value: '+53%', color: 'var(--jade)' },
+          { label: 'ICT share of 482 grants', value: '~12%', color: 'var(--text-secondary)' },
         ].map(stat => (
           <div key={stat.label} style={{
             background: 'var(--warm-white)', border: '1px solid var(--parchment)',

--- a/app/cover-letter/page.tsx
+++ b/app/cover-letter/page.tsx
@@ -266,13 +266,13 @@ function CoverLetterContent() {
               display: 'flex', flexDirection: 'column', gap: '0.4rem',
             }}>
               {history.map(item => (
-                <button key={item.id} onClick={() => loadFromHistory(item)} style={{
-                  background: 'none', border: 'none', textAlign: 'left',
-                  padding: '0.5rem 0.6rem', borderRadius: '8px', cursor: 'pointer',
-                  fontSize: '0.85rem', color: 'var(--brown-dark)',
-                }}
-                  onMouseEnter={e => (e.currentTarget.style.background = 'var(--parchment)')}
-                  onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+                <button key={item.id} onClick={() => loadFromHistory(item)}
+                  className="cover-letter-history-item"
+                  style={{
+                    background: 'none', border: 'none', textAlign: 'left',
+                    padding: '0.5rem 0.6rem', borderRadius: '8px', cursor: 'pointer',
+                    fontSize: '0.85rem', color: 'var(--brown-dark)',
+                  }}
                 >
                   <strong>{item.job_title}</strong> at {item.company}
                   <span style={{ color: 'var(--text-muted)', fontSize: '0.78rem', marginLeft: '0.5rem' }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1450,3 +1450,13 @@ h3, h4 {
   background-image: radial-gradient(circle, rgba(0,0,0,0.18) 0.06em, transparent 0.06em);
   background-size: 0.55em 0.55em;
 }
+
+/* Cover-letter history item hover */
+.cover-letter-history-item:hover {
+  background: var(--parchment);
+}
+
+/* Resume external link hover */
+.resume-ext-link:hover {
+  text-decoration: underline;
+}

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -9,9 +9,8 @@ function ExternalLink({ href, children }: { href: string; children: React.ReactN
   const url = href.startsWith('http') ? href : `https://${href}`;
   return (
     <a href={url} target="_blank" rel="noopener noreferrer"
+      className="resume-ext-link"
       style={{ color: 'var(--terracotta)', textDecoration: 'none' }}
-      onMouseEnter={e => (e.currentTarget.style.textDecoration = 'underline')}
-      onMouseLeave={e => (e.currentTarget.style.textDecoration = 'none')}
     >
       {children}
     </a>

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 import { useAuth } from '@/components/AuthProvider';
 
@@ -286,7 +287,7 @@ export default function Comments({ slug }: { slug: string }) {
         </form>
       ) : (
         <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', marginBottom: '2rem' }}>
-          <a href="/login" style={{ color: 'var(--terracotta)', fontWeight: 600 }}>Sign in</a> to join the conversation.
+          <Link href="/login" style={{ color: 'var(--terracotta)', fontWeight: 600 }}>Sign in</Link> to join the conversation.
         </p>
       )}
 


### PR DESCRIPTION
## Summary

Implements high-priority security and style fixes from daily analyst report (issue #13, 2026-04-24).

**Security fixes:**
- `cover-letter/route.ts`: slice `jobTitle`/`company` to 200 chars before GPT-4o prompt — prevents payload inflation attack on the 50/day rate limit
- `interview/chat/route.ts`: cap each message `.content` to 2000 chars before spreading to OpenAI — prevents 10 MB message inflation across the 10-message window
- `admin/users/[id]/route.ts`: UUID regex guard on both PATCH and DELETE before hitting Supabase — matches the pattern already used in `alerts/route.ts`
- `comments/[id]/route.ts`: same UUID regex guard on PATCH and DELETE

**Code quality:**
- `components/Comments.tsx`: replace `<a href="/login">` with `<Link href="/login">` for client-side navigation (no full page reload)

**Style (dark-mode + AGENTS.md compliance):**
- `cover-letter/page.tsx`: remove `onMouseEnter/Leave` JS handlers → CSS `.cover-letter-history-item:hover` class
- `app/resume/page.tsx`: remove `onMouseEnter/Leave` JS handlers → CSS `.resume-ext-link:hover` class
- `app/globals.css`: add the two new hover classes
- `Sponsorship.tsx`: replace hardcoded `#7c3aed` / `#10b981` / `#0369a1` KPI accents with design tokens (`var(--gold)`, `var(--jade)`, `var(--text-secondary)`)

## Test plan

- [ ] Cover-letter form: paste a 500-char job title — verify it's truncated to 200 in the prompt sent to OpenAI
- [ ] Interview chat: verify long messages are capped client-side and don't cause token blow-up
- [ ] Admin user ban/PATCH with a non-UUID id string — should return 400 before hitting DB
- [ ] Comments PATCH/DELETE with a non-UUID id — should return 400
- [ ] Comments "Sign in" link navigates without full reload
- [ ] Cover-letter history items show hover background via CSS (not JS)
- [ ] Resume external links show underline on hover (CSS only)
- [ ] Sponsorship KPI stats render correctly in both light and dark mode

https://claude.ai/code/session_01XMazrmHAUYAYCvmMG1ZZm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMazrmHAUYAYCvmMG1ZZm5)_