### PR TITLE
hotfix(csp): drop nonce — broke hydration on static pages

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -4,14 +4,17 @@ import { NextRequest, NextResponse } from 'next/server';
 // Fail-closed: empty string means isOwner never matches if env var is unset.
 const OWNER_EMAIL = process.env.OWNER_EMAIL?.toLowerCase() ?? '';
 
-function buildCsp(nonce: string): string {
+function buildCsp(): string {
   const isDev = process.env.NODE_ENV === 'development';
   return [
     "default-src 'self'",
-    // nonce tags each request's scripts uniquely. unsafe-inline retained for
-    // compatibility with statically generated pages (no strict-dynamic yet).
+    // Static prerender + ISR caching means inline scripts in cached HTML can't
+    // carry a per-request nonce. With nonce present, modern browsers (CSP2+)
+    // ignore 'unsafe-inline' and block all unnonced inline scripts, breaking
+    // React hydration. Until pages are dynamic OR nonce is plumbed through
+    // <Script> at render time, fall back to 'unsafe-inline' only.
     // unsafe-eval is dev-only: React uses it for error-stack reconstruction.
-    `script-src 'self' 'nonce-${nonce}' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://js.stripe.com https://va.vercel-scripts.com`,
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://js.stripe.com https://va.vercel-scripts.com`,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https://*.googleusercontent.com https://*.githubusercontent.com https://img.youtube.com https://i.ytimg.com https://cdn.simpleicons.org https://img.logo.dev https://www.google.com",
     "font-src 'self'",
@@ -27,13 +30,9 @@ function buildCsp(nonce: string): string {
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Per-request nonce — unique, unpredictable, base64-encoded UUID.
-  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
-  const csp = buildCsp(nonce);
+  const csp = buildCsp();
 
-  // Forward nonce to server components via request header (x-nonce).
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-nonce', nonce);
   requestHeaders.set('content-security-policy', csp);
 
   // Protected routes need a Supabase auth check.


### PR DESCRIPTION
## Problem

Site at https://gradland.au renders SSR HTML but React never hydrates:
- Hero stuck on skeleton placeholders
- Tools/Insights dropdowns unclickable
- Only Pricing (plain \`<Link>\`) works

## Root cause

\`proxy.ts\` builds CSP with per-request nonce:

\`\`\`
script-src 'self' 'nonce-RANDOM' 'unsafe-inline' …
\`\`\`

But pages are statically prerendered (\`x-nextjs-prerender: 1\`) + ISR-cached at the edge (\`x-vercel-cache: HIT\`). Cached HTML body has 21 inline \`<script>\` tags, **zero with \`nonce=\` attribute** — nonce was generated and forwarded as \`x-nonce\` header but never applied to scripts at render time.

Modern browsers (CSP Level 2+) **ignore \`'unsafe-inline'\` once \`nonce-\` is present**. Result: every inline script blocked → React hydration blocked.

Latent since 33cef88 (2026-05-06). Surfaced today when gradland.au domain went live.

## Fix

Remove \`'nonce-\${nonce}'\` from \`script-src\`; keep \`'unsafe-inline'\`. All other CSP directives retained:
- \`default-src 'self'\`
- \`frame-ancestors 'none'\`
- \`object-src 'none'\`
- \`base-uri 'self'\`
- \`connect-src\` allowlist
- HSTS, X-Frame-Options, etc.

Nonce removal = no real security loss — nonce was security theatre because it never reached any inline script.

## Test plan

- [ ] Vercel preview deploys without build error
- [ ] Visit preview URL — hero loads (no skeleton freeze)
- [ ] Tools / Insights dropdowns open
- [ ] Login flow works
- [ ] Stripe checkout button clickable
- [ ] After merge: prod gradland.au unblocked

## Follow-up

Proper nonce-based CSP requires either:
1. Make pages dynamic (lose ISR perf), OR
2. Plumb nonce through render tree via \`await headers()\` → pass to every \`<Script>\`

Defer until time permits. \`'unsafe-inline'\` acceptable interim posture.