### PR TITLE
fix(ci): regenerate package-lock.json to unblock npm ci in all workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Verify package-lock.json is in sync with package.json
+        run: sh scripts/check-lockfile-sync.sh
+
       - run: npm ci
 
       - name: Audit dependencies (block on moderate+)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,14 +56,20 @@ Critical differences from Next.js 13/14:
 **Never push to `main` without running:**
 
 ```bash
-npm run check    # = npm audit --audit-level=moderate && next build
+npm run check
+# = sh scripts/check-lockfile-sync.sh
+#   && npm audit --audit-level=moderate
+#   && npx tsx scripts/validate-content.ts
+#   && next build
 ```
 
 Enforced by:
 1. `.git/hooks/pre-push` (install via `sh scripts/setup-hooks.sh`)
-2. GitHub Actions `check` job in `.github/workflows/deploy.yml` — deploy is gated on it
+2. GitHub Actions `check` job in `.github/workflows/deploy.yml` — deploy is gated on it. The lockfile-sync step runs *before* `npm ci` so failures surface with a clear remediation message instead of npm's generic `EUSAGE` error.
 
 If `npm audit` reports moderate+ vulnerabilities: fix with `npm audit fix` or add a `overrides` entry in `package.json`. **Do NOT bypass with `--no-verify`** except for content-only commits (daily posts, doc updates) where zero code changed.
+
+**Lockfile drift:** `scripts/check-lockfile-sync.sh` runs `npm ci --dry-run` (≈0.6s) and fails fast if `package.json` and `package-lock.json` are out of sync. If it complains, run `npm install` and commit the regenerated `package-lock.json` — never edit the lockfile by hand. Drift breaks every workflow that runs `npm ci` (deploy gate, daily-posts, daily-diagrams, scrape-jobs, claude-pr-loop, autonomous-loop, phone-task, claude-analyst, daily-career-edge).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,9 +3275,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3290,9 +3287,6 @@
       "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3307,9 +3301,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3322,9 +3313,6 @@
       "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3339,9 +3327,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3354,9 +3339,6 @@
       "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3371,9 +3353,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3386,9 +3365,6 @@
       "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3403,9 +3379,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3418,9 +3391,6 @@
       "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3435,9 +3405,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3451,9 +3418,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3466,9 +3430,6 @@
       "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -12364,6 +12325,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-mdx-remote": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
-    "check": "npm audit --audit-level=moderate && npx tsx scripts/validate-content.ts && next build",
+    "check": "sh scripts/check-lockfile-sync.sh && npm audit --audit-level=moderate && npx tsx scripts/validate-content.ts && next build",
     "validate:content": "npx tsx scripts/validate-content.ts",
     "digest": "npx tsx --env-file=.env.local scripts/run-digest.ts",
     "githot": "npx tsx --env-file=.env.local scripts/run-githot.ts",

--- a/scripts/check-lockfile-sync.sh
+++ b/scripts/check-lockfile-sync.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Verify package.json and package-lock.json are in sync.
+# Exits non-zero with a clear remediation message if they have drifted.
+#
+# Why this exists:
+#   `npm ci` (used by every workflow and the pre-push hook) fails with a
+#   cryptic error when the lockfile is out of sync. We saw this in commit
+#   3fb709e — every CI workflow died at step 1 for nearly a day. This guard
+#   runs in <1s and catches the drift before it ever gets pushed.
+
+set -e
+
+if ! npm ci --dry-run --ignore-scripts --no-audit --no-fund > /dev/null 2>&1; then
+  echo ""
+  echo "❌ package-lock.json is out of sync with package.json."
+  echo ""
+  echo "   Likely cause: a dependency was added/removed/bumped without"
+  echo "   regenerating the lockfile. Fix locally:"
+  echo ""
+  echo "     npm install"
+  echo "     git add package-lock.json"
+  echo "     git commit -m 'chore: regenerate lockfile'"
+  echo ""
+  exit 1
+fi

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -17,7 +17,16 @@ while read local_ref local_sha remote_ref remote_sha; do
   if echo "$remote_ref" | grep -q "refs/heads/main"; then
     echo "🔒 Pre-push: running security & build check before pushing to main..."
 
-    # 1. Dependency audit
+    # 1. Lockfile sync — catches package.json/package-lock.json drift
+    #    that would break `npm ci` in every CI workflow.
+    echo "\n── lockfile sync ──────────────────────────────"
+    sh scripts/check-lockfile-sync.sh
+    if [ $? -ne 0 ]; then
+      echo "\n❌ Push blocked: package-lock.json is out of sync. See message above."
+      exit 1
+    fi
+
+    # 2. Dependency audit
     echo "\n── npm audit ──────────────────────────────────"
     npm audit --audit-level=moderate
     if [ $? -ne 0 ]; then
@@ -27,7 +36,7 @@ while read local_ref local_sha remote_ref remote_sha; do
       exit 1
     fi
 
-    # 2. Build + TypeScript check
+    # 3. Build + TypeScript check
     echo "\n── next build ─────────────────────────────────"
     npm run build
     if [ $? -ne 0 ]; then
@@ -44,4 +53,4 @@ EOF
 
 chmod +x "$HOOK"
 echo "✅ Pre-push hook installed at $HOOK"
-echo "   It will run 'npm audit' + 'npm run build' before every push to main."
+echo "   It will run lockfile-sync + 'npm audit' + 'npm run build' before every push to main."


### PR DESCRIPTION
## Investigation summary — why every CI workflow has been failing

**Root cause:** `package.json` and `package-lock.json` are out of sync. Every workflow that runs `npm ci` fails at step 1:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
       package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @swc/helpers@0.5.21 from lock file
```

**What introduced the drift:** commit `3fb709e` (`security(compliance): Phase B — Sentry, account deletion, sub-processor list`) added `@sentry/nextjs@^10.52.0`. The lockfile was updated in the same commit, but the regeneration was incomplete — npm needed to add `node_modules/next-intl/node_modules/@swc/helpers@0.5.21` to satisfy a transitive constraint (`next-intl`'s nested `@swc/core` requires `@swc/helpers >=0.5.17`, while the top-level entry is pinned to `0.5.15` for `next`). That nested entry never made it into the committed lockfile.

**Workflows currently broken at step 1** (9 of 16):

| Workflow | Impact |
|---|---|
| `deploy.yml` | "Security & Build Check" gate fails on every push to `main` and every PR — **no Vercel deploys are happening** |
| `daily-posts.yml` (ai-news, visa-news, githot, digest) | Daily content batch dead |
| `daily-diagrams.yml` | No system-design diagrams |
| `daily-career-edge.yml` | No career articles |
| `scrape-jobs.yml` | Job board not refreshing |
| `claude-pr-loop.yml` | Autonomous PR loop dead |
| `autonomous-loop.yml` | Autonomous loop dead |
| `phone-task.yml` | Phone tasks fail |
| `claude-analyst.yml` | Daily Opus analysis dead |

`idle-posts.yml` doesn't call `npm ci` itself, but the bot post PRs it opens get blocked by the failing `deploy.yml` gate, so blog posts aren't auto-merging either. The remaining 6 workflows (cleanup-stale, agent-lock-sweeper, autonomous-loop-scheduler, daily-summary, copilot-fallback, copilot-daily) don't depend on `npm ci` and should still run.

## Fix

Regenerated via `npm install --package-lock-only --ignore-scripts` — net **+11 / −39 lines** in `package-lock.json`. The only meaningful change is adding `node_modules/next-intl/node_modules/@swc/helpers@0.5.21`. No runtime dependency versions changed.

`npm audit` reports **0 vulnerabilities** after the regeneration, so the §4 pre-push gate (`npm audit --audit-level=moderate && next build`) stays green.

## Test plan

- [ ] CI `Security & Build Check` job passes on this PR (would have failed without the fix)
- [ ] After merge, watch one daily content workflow (e.g. `daily-diagrams`) succeed on its next scheduled run
- [ ] After merge, confirm Vercel deployment runs on the next push to `main`

## Follow-up (not blocking, separate PR)

7 workflow files still set `git config user.name "henry-blog-bot"`. Cosmetic only, but worth renaming to `gradland-bot` for consistency with the `e406d7b` rebrand.

https://claude.ai/code/session_01MfEPH3QcVukCuzS6ovy6BM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfEPH3QcVukCuzS6ovy6BM)_