### PR TITLE
fix: rate-limit channel-videos + shared supabase server in progress

### DIFF
--- a/app/api/learn/channel-videos/route.ts
+++ b/app/api/learn/channel-videos/route.ts
@@ -1,4 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { checkRateLimit } from '@/lib/rate-limit-db';
+
+function getIp(req: NextRequest): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? req.headers.get('x-real-ip')
+      ?? 'unknown';
+}
 
 // In-process cache for uploads playlist IDs — these never change so we only
 // fetch them once per server instance per channel.
@@ -24,6 +31,11 @@ export async function GET(req: NextRequest) {
   const maxResults = 30; // 30 per page — balanced between speed and quota
 
   if (!channelId) return NextResponse.json({ error: 'Missing channelId' }, { status: 400 });
+
+  const ip = getIp(req);
+  if (await checkRateLimit('learn/channel-videos:' + ip, 3600, 60)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
 
   const apiKey = process.env.YOUTUBE_API_KEY;
   if (!apiKey) return NextResponse.json({ error: 'YouTube API key not configured' }, { status: 503 });

--- a/app/api/learn/progress/route.ts
+++ b/app/api/learn/progress/route.ts
@@ -1,14 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createSupabaseServer } from '@/lib/auth-server';
 
 export async function POST(req: NextRequest) {
-  const cookieStore = await cookies();
-  const sb = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { getAll: () => cookieStore.getAll(), setAll: () => {} } },
-  );
+  const sb = await createSupabaseServer();
   const { data: { user } } = await sb.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -37,12 +31,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET(req: NextRequest) {
-  const cookieStore = await cookies();
-  const sb = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { getAll: () => cookieStore.getAll(), setAll: () => {} } },
-  );
+  const sb = await createSupabaseServer();
   const { data: { user } } = await sb.auth.getUser();
   if (!user) return NextResponse.json({ progress: [] });
 


### PR DESCRIPTION
## Summary

- **#217 (security)** — `app/api/learn/channel-videos/route.ts`: add IP-based `checkRateLimit` (60/hr) to prevent YouTube Data API quota exhaustion via random `channelId` requests. Matches `app/api/contact/route.ts` pattern.
- **#212 (quality)** — `app/api/learn/progress/route.ts`: replace inline `createServerClient`/`cookies` from `@supabase/ssr` with shared `createSupabaseServer()` from `lib/auth-server.ts` per AGENTS §5.2.

Closes #217
Closes #212

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Manual: GET `/api/learn/channel-videos?channelId=…` returns 429 after 60 reqs/hr/IP
- [ ] Manual: POST/GET `/api/learn/progress` still auth-gates and persists progress
- [ ] CI: dependency audit (pre-existing mermaid + next 16.x vulns; unrelated to this PR)

## Out of scope
- Pre-existing `npm audit` findings (mermaid <=10.9.5, next 16.0.0-16.2.5) — addressed by a separate dependency-bump PR.