### PR TITLE
production hardening — security + reliability + UX + deps

### DIFF
--- a/app/admin/analytics/error.tsx
+++ b/app/admin/analytics/error.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function AdminAnalyticsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[AdminAnalyticsError]', error.digest ?? error.message, error);
+    fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: error.message, digest: error.digest, url: typeof window !== 'undefined' ? window.location.href : '' }),
+    }).catch(() => {});
+  }, [error]);
+
+  return (
+    <div style={{ maxWidth: '480px', margin: '0 auto', padding: '6rem 1.5rem 4rem', textAlign: 'center' }}>
+      <p style={{ fontSize: '3rem', marginBottom: '1rem' }}>⚠️</p>
+      <h2 style={{ fontFamily: "'Lora', serif", fontSize: '1.75rem', fontWeight: 700, color: 'var(--brown-dark)', marginBottom: '0.75rem' }}>
+        Analytics unavailable
+      </h2>
+      <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: '2rem' }}>
+        Couldn’t load the analytics dashboard. The query may have timed out.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+        <button onClick={reset} style={{
+          background: 'var(--terracotta)', color: 'white', border: 'none',
+          padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
+        }}>
+          Try again
+        </button>
+        <Link href="/admin" style={{
+          border: '1px solid var(--parchment)', color: 'var(--brown-dark)',
+          textDecoration: 'none', padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 500,
+        }}>
+          Back to admin
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/analytics/loading.tsx
+++ b/app/admin/analytics/loading.tsx
@@ -1,0 +1,13 @@
+export default function AdminAnalyticsLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '40%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} style={{ height: '110px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.7 }} />
+        ))}
+      </div>
+      <div style={{ height: '320px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.6 }} />
+    </div>
+  );
+}

--- a/app/admin/job-listings/error.tsx
+++ b/app/admin/job-listings/error.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function AdminJobListingsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[AdminJobListingsError]', error.digest ?? error.message, error);
+    fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: error.message, digest: error.digest, url: typeof window !== 'undefined' ? window.location.href : '' }),
+    }).catch(() => {});
+  }, [error]);
+
+  return (
+    <div style={{ maxWidth: '480px', margin: '0 auto', padding: '6rem 1.5rem 4rem', textAlign: 'center' }}>
+      <p style={{ fontSize: '3rem', marginBottom: '1rem' }}>⚠️</p>
+      <h2 style={{ fontFamily: "'Lora', serif", fontSize: '1.75rem', fontWeight: 700, color: 'var(--brown-dark)', marginBottom: '0.75rem' }}>
+        Job listings unavailable
+      </h2>
+      <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: '2rem' }}>
+        Couldn’t load the moderation queue. Try again — no listings were lost.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+        <button onClick={reset} style={{
+          background: 'var(--terracotta)', color: 'white', border: 'none',
+          padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
+        }}>
+          Try again
+        </button>
+        <Link href="/admin" style={{
+          border: '1px solid var(--parchment)', color: 'var(--brown-dark)',
+          textDecoration: 'none', padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 500,
+        }}>
+          Back to admin
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/job-listings/loading.tsx
+++ b/app/admin/job-listings/loading.tsx
@@ -1,0 +1,10 @@
+export default function AdminJobListingsLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '40%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} style={{ height: '90px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 12, marginBottom: '0.75rem', opacity: 0.7 }} />
+      ))}
+    </div>
+  );
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,14 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
+import { checkRateLimit } from '@/lib/rate-limit-db';
 
 const SUPPORT_INBOX = 'admin@gradland.au';
 const FROM          = 'Gradland <noreply@gradland.au>';
 
 const VALID_TOPICS = new Set(['general', 'billing', 'privacy', 'bug', 'partnership']);
-
-const ipLog = new Map<string, number[]>();
-const RATE_LIMIT  = 5;
-const WINDOW_MS   = 60 * 60 * 1000;
 
 function getIp(req: NextRequest): string {
   return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
@@ -16,22 +13,11 @@ function getIp(req: NextRequest): string {
       ?? 'unknown';
 }
 
-function checkRateLimit(ip: string): boolean {
-  const now      = Date.now();
-  const existing = ipLog.get(ip);
-  const recent   = (existing ?? []).filter(t => now - t < WINDOW_MS);
-  if (recent.length >= RATE_LIMIT) return false;
-  if (!existing && ipLog.size >= 5000) ipLog.delete(ipLog.keys().next().value!);
-  recent.push(now);
-  ipLog.set(ip, recent);
-  return true;
-}
-
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 
 export async function POST(req: NextRequest) {
   const ip = getIp(req);
-  if (!checkRateLimit(ip)) {
+  if (await checkRateLimit('contact:' + ip, 3600, 5)) {
     return NextResponse.json(
       { error: 'Too many messages. Please email admin@gradland.au directly.' },
       { status: 429 },

--- a/app/api/cover-letter/route.ts
+++ b/app/api/cover-letter/route.ts
@@ -101,20 +101,25 @@ Write the cover letter now. 3-4 paragraphs, plain text only, no headers or bulle
     ],
     max_tokens: 800,
     stream: true,
-  });
+  }, { signal: AbortSignal.timeout(45000) });
 
   const encoder = new TextEncoder();
   const chunks: string[] = [];
   const readable = new ReadableStream({
     async start(controller) {
-      for await (const chunk of stream) {
-        const text = chunk.choices[0]?.delta?.content ?? '';
-        if (text) {
-          controller.enqueue(encoder.encode(text));
-          chunks.push(text);
+      try {
+        for await (const chunk of stream) {
+          const text = chunk.choices[0]?.delta?.content ?? '';
+          if (text) {
+            controller.enqueue(encoder.encode(text));
+            chunks.push(text);
+          }
         }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+        return;
       }
-      controller.close();
       // Write to both caches after stream completes (fire-and-forget)
       const fullText = chunks.join('');
       if (fullText.length > 100) {

--- a/app/api/dashboard/summary/route.ts
+++ b/app/api/dashboard/summary/route.ts
@@ -51,6 +51,7 @@ export async function GET() {
     sb.from('job_applications')
       .select('status')
       .eq('user_id', uid)
+      .order('applied_at', { ascending: false })
       .limit(500),
   ]);
 

--- a/app/api/interview/chat/route.ts
+++ b/app/api/interview/chat/route.ts
@@ -42,20 +42,24 @@ export async function POST(req: NextRequest) {
       model: 'gpt-4o-mini',
       messages: [
         { role: 'system', content: systemContent },
-        ...messages.slice(-10),
+        ...messages.slice(-10).map(m => ({ ...m, content: String(m.content ?? '').slice(0, 5000) })),
       ],
       max_tokens: 200,
       stream: true,
-    });
+    }, { signal: AbortSignal.timeout(30000) });
 
     const encoder = new TextEncoder();
     const readable = new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          const text = chunk.choices[0]?.delta?.content ?? '';
-          if (text) controller.enqueue(encoder.encode(text));
+        try {
+          for await (const chunk of stream) {
+            const text = chunk.choices[0]?.delta?.content ?? '';
+            if (text) controller.enqueue(encoder.encode(text));
+          }
+          controller.close();
+        } catch (err) {
+          controller.error(err);
         }
-        controller.close();
       },
     });
 

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sourceLabel, makeSingleSource, formatAttribution, type SourceRef } from '@/lib/jobs-sources';
+import { checkRateLimit } from '@/lib/rate-limit-db';
+
+function getIp(req: NextRequest): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? req.headers.get('x-real-ip')
+      ?? 'unknown';
+}
 
 const APP_ID          = process.env.ADZUNA_APP_ID;
 const APP_KEY         = process.env.ADZUNA_APP_KEY;
@@ -565,6 +572,11 @@ function dedupKey(title: string, company: string): string {
 // ─── Route ────────────────────────────────────────────────────────────────────
 
 export async function GET(req: NextRequest) {
+  const ip = getIp(req);
+  if (await checkRateLimit('jobs:' + ip, 3600, 120)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const sp = req.nextUrl.searchParams;
   const keywords  = sp.get('keywords') || 'software developer';
   const location  = sp.get('location') || 'Brisbane';

--- a/app/api/learn/channel-videos/route.ts
+++ b/app/api/learn/channel-videos/route.ts
@@ -10,7 +10,7 @@ async function getUploadsPlaylistId(channelId: string, apiKey: string): Promise<
 
   const res = await fetch(
     `https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=${channelId}&key=${apiKey}`,
-    { next: { revalidate: 86400 } }, // 24h — uploads playlist ID never changes
+    { next: { revalidate: 86400 }, signal: AbortSignal.timeout(8000) }, // 24h cache — playlist ID never changes
   );
   const data = await res.json();
   const id: string = data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads ?? '';
@@ -43,7 +43,9 @@ export async function GET(req: NextRequest) {
     const res = await fetch(
       `https://www.googleapis.com/youtube/v3/playlistItems?${params}`,
       // First page is cacheable; subsequent pages must not be (different pageToken each time)
-      pageToken ? { cache: 'no-store' } : { next: { revalidate: 3600 } },
+      pageToken
+        ? { cache: 'no-store', signal: AbortSignal.timeout(8000) }
+        : { next: { revalidate: 3600 }, signal: AbortSignal.timeout(8000) },
     );
 
     if (!res.ok) {

--- a/app/api/learn/progress/route.ts
+++ b/app/api/learn/progress/route.ts
@@ -18,6 +18,7 @@ export async function POST(req: NextRequest) {
 
   const { videoId, videoTitle, quizScore, completed } = body;
   if (!videoId || !videoTitle) return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  if (!/^[A-Za-z0-9_-]{11}$/.test(videoId)) return NextResponse.json({ error: 'Invalid videoId' }, { status: 400 });
 
   const update: Record<string, unknown> = {
     user_id:     user.id,

--- a/app/api/learn/video-meta/route.ts
+++ b/app/api/learn/video-meta/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createSupabaseService } from '@/lib/auth-server';
+import { checkRateLimit } from '@/lib/rate-limit-db';
 
 const HOST = 'youtube138.p.rapidapi.com';
+
+function getIp(req: NextRequest): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? req.headers.get('x-real-ip')
+      ?? 'unknown';
+}
 
 export async function GET(req: NextRequest) {
   const videoId = req.nextUrl.searchParams.get('videoId');
@@ -27,20 +34,32 @@ export async function GET(req: NextRequest) {
     });
   }
 
+  // ── Cache miss → about to spend RapidAPI quota. Gate by IP. ───────────────
+  const ip = getIp(req);
+  if (await checkRateLimit('video-meta:' + ip, 3600, 30)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   // ── Fallback: fetch from RapidAPI ─────────────────────────────────────────
   const apiKey = process.env.RAPIDAPI_KEY;
   if (!apiKey) return NextResponse.json({ error: 'RapidAPI key not configured' }, { status: 503 });
 
-  const res = await fetch(`https://${HOST}/video/details/`, {
-    method:  'POST',
-    headers: {
-      'Content-Type':    'application/json',
-      'x-rapidapi-host': HOST,
-      'x-rapidapi-key':  apiKey,
-    },
-    body: JSON.stringify({ id: videoId, hl: 'en', gl: 'AU' }),
-    cache: 'no-store', // POST body not part of Next.js cache key — never cache
-  });
+  let res: Response;
+  try {
+    res = await fetch(`https://${HOST}/video/details/`, {
+      method:  'POST',
+      headers: {
+        'Content-Type':    'application/json',
+        'x-rapidapi-host': HOST,
+        'x-rapidapi-key':  apiKey,
+      },
+      body:   JSON.stringify({ id: videoId, hl: 'en', gl: 'AU' }),
+      cache:  'no-store', // POST body not part of Next.js cache key — never cache
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    return NextResponse.json({ error: 'Upstream timeout' }, { status: 504 });
+  }
 
   if (!res.ok) return NextResponse.json({ error: 'Video not found' }, { status: 404 });
 

--- a/app/api/learn/videos/route.ts
+++ b/app/api/learn/videos/route.ts
@@ -13,7 +13,7 @@ interface YTItem {
 async function getUploadsPlaylistId(apiKey: string): Promise<string> {
   const res = await fetch(
     `https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=${IBM_CHANNEL_ID}&key=${apiKey}`,
-    { next: { revalidate: 86400 } }, // 24h — playlist ID never changes
+    { next: { revalidate: 86400 }, signal: AbortSignal.timeout(8000) }, // 24h cache — playlist ID never changes
   );
   const data = await res.json();
   return data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads ?? '';
@@ -28,7 +28,7 @@ async function fetchVideos(apiKey: string, playlistId: string, pageToken?: strin
   });
   if (pageToken) params.set('pageToken', pageToken);
 
-  const res  = await fetch(`https://www.googleapis.com/youtube/v3/playlistItems?${params}`, { next: { revalidate: 3600 } });
+  const res  = await fetch(`https://www.googleapis.com/youtube/v3/playlistItems?${params}`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(8000) });
   const data = await res.json();
 
   const videos: YTItem[] = (data.items ?? []).map((item: {

--- a/app/interview-prep/loading.tsx
+++ b/app/interview-prep/loading.tsx
@@ -1,0 +1,13 @@
+export default function InterviewPrepLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '45%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem' }}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} style={{ height: '36px', width: '120px', background: 'var(--parchment)', borderRadius: 18, opacity: 0.5 }} />
+        ))}
+      </div>
+      <div style={{ height: '320px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.6 }} />
+    </div>
+  );
+}

--- a/app/learn/loading.tsx
+++ b/app/learn/loading.tsx
@@ -1,0 +1,12 @@
+export default function LearnLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '50%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '1rem' }}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} style={{ height: '180px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.7 }} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/resume/loading.tsx
+++ b/app/resume/loading.tsx
@@ -1,0 +1,9 @@
+export default function ResumeLoading() {
+  return (
+    <div style={{ maxWidth: '760px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '55%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ height: '180px', background: 'var(--warm-white)', border: '1px dashed var(--parchment)', borderRadius: 14, marginBottom: '1.25rem', opacity: 0.7 }} />
+      <div style={{ height: '320px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.6 }} />
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1951,15 +1951,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1989,11 +1989,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2005,11 +2008,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2021,11 +2027,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2037,11 +2046,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2053,9 +2065,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2069,9 +2081,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -10838,9 +10850,9 @@
       "peer": true
     },
     "node_modules/mermaid": {
-      "version": "10.9.5",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.5.tgz",
-      "integrity": "sha512-eRlKEjzak4z1rcXeCd1OAlyawhrptClQDo8OuI8n6bSVqJ9oMfd5Lrf3Q+TdJHewi/9AIOc3UmEo8Fz+kNzzuQ==",
+      "version": "10.9.6",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.6.tgz",
+      "integrity": "sha512-XRjjRaI4aPCAMpVaOhxIwLYdx3U4Cb6mN0M268ggFAfFRqsvyFW8zxWbEZazN/mPkqsVWThb0oa1UawWK+XMNg==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.1",
@@ -10861,7 +10873,7 @@
         "non-layered-tidy-tree-layout": "^2.0.2",
         "stylis": "^4.1.3",
         "ts-dedent": "^2.2.0",
-        "uuid": "^9.0.0",
+        "uuid": "^9.0.0 || ^10 || ^11.1.0 || ^12 || ^13 || ^14.0.0",
         "web-worker": "^1.2.0"
       }
     },
@@ -12237,12 +12249,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -12256,14 +12268,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/supabase/032_error_logs.sql
+++ b/supabase/032_error_logs.sql
@@ -1,0 +1,26 @@
+-- Server-side error log sink for `app/api/log-error/route.ts`.
+-- Pairs with Sentry — Sentry handles alerting, this table gives the admin
+-- panel a cheap queryable history without pulling from the Sentry API.
+-- Inserts come only from the service-role client; RLS denies all direct access.
+
+CREATE TABLE IF NOT EXISTS public.error_logs (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  message    text        NOT NULL,
+  digest     text,
+  url        text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.error_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "No direct access to error_logs"
+  ON public.error_logs
+  FOR ALL
+  USING (false);
+
+CREATE INDEX IF NOT EXISTS error_logs_created_at_idx
+  ON public.error_logs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS error_logs_digest_idx
+  ON public.error_logs (digest)
+  WHERE digest IS NOT NULL;

--- a/supabase/033_index_post_comments_user.sql
+++ b/supabase/033_index_post_comments_user.sql
@@ -1,0 +1,10 @@
+-- Speed up comment-ownership lookups in `app/api/comments/[id]/route.ts`
+-- (DELETE/PATCH filter by user_id to enforce ownership before mutating).
+-- Existing indexes cover (post_slug, created_at) and (parent_id) but not
+-- (user_id), so the auth check is a sequential scan as the table grows.
+--
+-- video_progress already covers (user_id, video_id) via the UNIQUE
+-- constraint in migration 006, so no separate index is needed there.
+
+CREATE INDEX IF NOT EXISTS post_comments_user_idx
+  ON public.post_comments (user_id);


### PR DESCRIPTION
## Summary

Multi-commit hardening sweep on top of `main`. Each fix is a separate commit for clean revert.

**Security**
- `feat(db): error_logs migration` — restores the Supabase sink behind `app/api/log-error/route.ts` (was silently failing the insert; only Sentry captured).
- `refactor(contact): DB-backed rate limit` — replaces in-memory `ipLog` Map that resets on Vercel Fluid Compute recycle.
- `fix(security): video-meta cache miss rate-limited + timed out` — 30/hr/IP gate before paid RapidAPI fetch; `AbortSignal.timeout(8000)`.
- `fix(security): /api/jobs GET rate-limited` — public endpoint aggregating Adzuna/JSearch/ScraperAPI/Remotive/Jobicy. 120/hr/IP.
- `fix(validation): YouTube videoId regex in learn/progress` — rejects malformed strings before upsert.

**Reliability**
- `fix(reliability): AbortSignal.timeout + stream error handlers` — every YouTube fetch in `learn/videos` + `learn/channel-videos` now times out at 8s. OpenAI streams in `cover-letter` + `interview/chat` get 45s/30s connect timeout and `try/catch` inside `start(controller)` so SDK errors trigger `controller.error()` instead of silent truncation. `interview/chat` also caps each message at 5000 chars before sending.
- `fix(reliability): dashboard summary orders applications by recency` — `.limit(500)` had no `order`, so truncation discarded arbitrary rows.

**UX**
- `ux: error.tsx + loading.tsx for missing segments` — added to `admin/analytics`, `admin/job-listings`, `learn`, `resume`, `interview-prep`. Error pages report to `/api/log-error`.

**Performance / Deps**
- `perf(db): post_comments(user_id) index` — comment ownership lookups in DELETE/PATCH were sequential scans.
- `chore(deps): npm audit fix` — clears pre-existing next + mermaid advisories. `npm audit` now reports 0 vulnerabilities. `package.json` unchanged; only lockfile.

## Prod migrations already applied
- `032_error_logs` ✅
- `033_index_post_comments_user` ✅

## Out of scope (skipped during this batch)
- Stripe `/api/checkout` origin allowlist — audit claim was incorrect; existing `?? 'https://gradland.au'` fallback already fails-safe.
- Au-insights chart lazy-loading — already shipped (audit was stale; `JobMarketCharts` + `SponsorshipCharts` already `dynamic()` imports).
- Cover-letter / resume page Server-Component extraction — refactor with non-trivial risk to existing streaming + form state.
- Vercel AI SDK migration — refactor, not hardening.

## Test plan
- [x] `npm run check` clean (audit 0, content validate, next build) — see EXIT_FINAL:0
- [ ] Prod smoke after merge:
  - [ ] Hit `/api/contact` 6× from same IP → 429 on 6th
  - [ ] Hit `/api/jobs?tab=au` 121× → 429
  - [ ] POST `/api/learn/progress` with `videoId=xx` → 400
  - [ ] Verify `error_logs` row appears after `Sentry.captureMessage` smoke
  - [ ] Confirm admin/analytics + admin/job-listings render skeleton then content (or error page on failure)