### PR TITLE
production hardening v2 — rebased on current main

### DIFF
--- a/__tests__/api/dashboard-summary.test.ts
+++ b/__tests__/api/dashboard-summary.test.ts
@@ -35,6 +35,7 @@ function makeAppsChain(rows: { status: string }[] = []) {
   const c: any = {};
   c.select = vi.fn().mockReturnValue(c);
   c.eq     = vi.fn().mockReturnValue(c);
+  c.order  = vi.fn().mockReturnValue(c);
   c.limit  = vi.fn().mockResolvedValue({ data: rows, error: null });
   return c;
 }

--- a/app/admin/analytics/error.tsx
+++ b/app/admin/analytics/error.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function AdminAnalyticsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[AdminAnalyticsError]', error.digest ?? error.message, error);
+    fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: error.message, digest: error.digest, url: typeof window !== 'undefined' ? window.location.href : '' }),
+    }).catch(() => {});
+  }, [error]);
+
+  return (
+    <div style={{ maxWidth: '480px', margin: '0 auto', padding: '6rem 1.5rem 4rem', textAlign: 'center' }}>
+      <p style={{ fontSize: '3rem', marginBottom: '1rem' }}>⚠️</p>
+      <h2 style={{ fontFamily: "'Lora', serif", fontSize: '1.75rem', fontWeight: 700, color: 'var(--brown-dark)', marginBottom: '0.75rem' }}>
+        Analytics unavailable
+      </h2>
+      <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: '2rem' }}>
+        Couldn’t load the analytics dashboard. The query may have timed out.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+        <button onClick={reset} style={{
+          background: 'var(--terracotta)', color: 'white', border: 'none',
+          padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
+        }}>
+          Try again
+        </button>
+        <Link href="/admin" style={{
+          border: '1px solid var(--parchment)', color: 'var(--brown-dark)',
+          textDecoration: 'none', padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 500,
+        }}>
+          Back to admin
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/analytics/loading.tsx
+++ b/app/admin/analytics/loading.tsx
@@ -1,0 +1,13 @@
+export default function AdminAnalyticsLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '40%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} style={{ height: '110px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.7 }} />
+        ))}
+      </div>
+      <div style={{ height: '320px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.6 }} />
+    </div>
+  );
+}

--- a/app/admin/job-listings/error.tsx
+++ b/app/admin/job-listings/error.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function AdminJobListingsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[AdminJobListingsError]', error.digest ?? error.message, error);
+    fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: error.message, digest: error.digest, url: typeof window !== 'undefined' ? window.location.href : '' }),
+    }).catch(() => {});
+  }, [error]);
+
+  return (
+    <div style={{ maxWidth: '480px', margin: '0 auto', padding: '6rem 1.5rem 4rem', textAlign: 'center' }}>
+      <p style={{ fontSize: '3rem', marginBottom: '1rem' }}>⚠️</p>
+      <h2 style={{ fontFamily: "'Lora', serif", fontSize: '1.75rem', fontWeight: 700, color: 'var(--brown-dark)', marginBottom: '0.75rem' }}>
+        Job listings unavailable
+      </h2>
+      <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', lineHeight: 1.7, marginBottom: '2rem' }}>
+        Couldn’t load the moderation queue. Try again — no listings were lost.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+        <button onClick={reset} style={{
+          background: 'var(--terracotta)', color: 'white', border: 'none',
+          padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
+        }}>
+          Try again
+        </button>
+        <Link href="/admin" style={{
+          border: '1px solid var(--parchment)', color: 'var(--brown-dark)',
+          textDecoration: 'none', padding: '0.65rem 1.5rem', borderRadius: '10px',
+          fontSize: '0.92rem', fontWeight: 500,
+        }}>
+          Back to admin
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/job-listings/loading.tsx
+++ b/app/admin/job-listings/loading.tsx
@@ -1,0 +1,10 @@
+export default function AdminJobListingsLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '40%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} style={{ height: '90px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 12, marginBottom: '0.75rem', opacity: 0.7 }} />
+      ))}
+    </div>
+  );
+}

--- a/app/api/cover-letter/route.ts
+++ b/app/api/cover-letter/route.ts
@@ -101,20 +101,25 @@ Write the cover letter now. 3-4 paragraphs, plain text only, no headers or bulle
     ],
     max_tokens: 800,
     stream: true,
-  });
+  }, { signal: AbortSignal.timeout(45000) });
 
   const encoder = new TextEncoder();
   const chunks: string[] = [];
   const readable = new ReadableStream({
     async start(controller) {
-      for await (const chunk of stream) {
-        const text = chunk.choices[0]?.delta?.content ?? '';
-        if (text) {
-          controller.enqueue(encoder.encode(text));
-          chunks.push(text);
+      try {
+        for await (const chunk of stream) {
+          const text = chunk.choices[0]?.delta?.content ?? '';
+          if (text) {
+            controller.enqueue(encoder.encode(text));
+            chunks.push(text);
+          }
         }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+        return;
       }
-      controller.close();
       // Write to both caches after stream completes (fire-and-forget)
       const fullText = chunks.join('');
       if (fullText.length > 100) {

--- a/app/api/dashboard/summary/route.ts
+++ b/app/api/dashboard/summary/route.ts
@@ -51,6 +51,7 @@ export async function GET() {
     sb.from('job_applications')
       .select('status')
       .eq('user_id', uid)
+      .order('applied_at', { ascending: false })
       .limit(500),
   ]);
 

--- a/app/api/interview/chat/route.ts
+++ b/app/api/interview/chat/route.ts
@@ -42,20 +42,24 @@ export async function POST(req: NextRequest) {
       model: 'gpt-4o-mini',
       messages: [
         { role: 'system', content: systemContent },
-        ...messages.slice(-10),
+        ...messages.slice(-10).map(m => ({ ...m, content: String(m.content ?? '').slice(0, 5000) })),
       ],
       max_tokens: 200,
       stream: true,
-    });
+    }, { signal: AbortSignal.timeout(30000) });
 
     const encoder = new TextEncoder();
     const readable = new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          const text = chunk.choices[0]?.delta?.content ?? '';
-          if (text) controller.enqueue(encoder.encode(text));
+        try {
+          for await (const chunk of stream) {
+            const text = chunk.choices[0]?.delta?.content ?? '';
+            if (text) controller.enqueue(encoder.encode(text));
+          }
+          controller.close();
+        } catch (err) {
+          controller.error(err);
         }
-        controller.close();
       },
     });
 

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createSupabaseServer } from '@/lib/auth-server';
 import { sourceLabel, makeSingleSource, formatAttribution, type SourceRef } from '@/lib/jobs-sources';
+import { checkRateLimit } from '@/lib/rate-limit-db';
+
+function getIp(req: NextRequest): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? req.headers.get('x-real-ip')
+      ?? 'unknown';
+}
 
 const APP_ID          = process.env.ADZUNA_APP_ID;
 const APP_KEY         = process.env.ADZUNA_APP_KEY;
@@ -569,6 +576,11 @@ function dedupKey(title: string, company: string): string {
 // ─── Route ────────────────────────────────────────────────────────────────────
 
 export async function GET(req: NextRequest) {
+  const ip = getIp(req);
+  if (await checkRateLimit('jobs:' + ip, 3600, 120)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const sp = req.nextUrl.searchParams;
   const keywords  = sp.get('keywords') || 'software developer';
   const location  = sp.get('location') || 'Brisbane';

--- a/app/api/learn/channel-videos/route.ts
+++ b/app/api/learn/channel-videos/route.ts
@@ -17,7 +17,7 @@ async function getUploadsPlaylistId(channelId: string, apiKey: string): Promise<
 
   const res = await fetch(
     `https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=${channelId}&key=${apiKey}`,
-    { next: { revalidate: 86400 } }, // 24h — uploads playlist ID never changes
+    { next: { revalidate: 86400 }, signal: AbortSignal.timeout(8000) }, // 24h cache — playlist ID never changes
   );
   const data = await res.json();
   const id: string = data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads ?? '';
@@ -57,7 +57,9 @@ export async function GET(req: NextRequest) {
     const res = await fetch(
       `https://www.googleapis.com/youtube/v3/playlistItems?${params}`,
       // First page is cacheable; subsequent pages must not be (different pageToken each time)
-      pageToken ? { cache: 'no-store' } : { next: { revalidate: 3600 } },
+      pageToken
+        ? { cache: 'no-store', signal: AbortSignal.timeout(8000) }
+        : { next: { revalidate: 3600 }, signal: AbortSignal.timeout(8000) },
     );
 
     if (!res.ok) {

--- a/app/api/learn/video-meta/route.ts
+++ b/app/api/learn/video-meta/route.ts
@@ -40,16 +40,22 @@ export async function GET(req: NextRequest) {
   const apiKey = process.env.RAPIDAPI_KEY;
   if (!apiKey) return NextResponse.json({ error: 'RapidAPI key not configured' }, { status: 503 });
 
-  const res = await fetch(`https://${HOST}/video/details/`, {
-    method:  'POST',
-    headers: {
-      'Content-Type':    'application/json',
-      'x-rapidapi-host': HOST,
-      'x-rapidapi-key':  apiKey,
-    },
-    body: JSON.stringify({ id: videoId, hl: 'en', gl: 'AU' }),
-    cache: 'no-store', // POST body not part of Next.js cache key — never cache
-  });
+  let res: Response;
+  try {
+    res = await fetch(`https://${HOST}/video/details/`, {
+      method:  'POST',
+      headers: {
+        'Content-Type':    'application/json',
+        'x-rapidapi-host': HOST,
+        'x-rapidapi-key':  apiKey,
+      },
+      body:   JSON.stringify({ id: videoId, hl: 'en', gl: 'AU' }),
+      cache:  'no-store', // POST body not part of Next.js cache key — never cache
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    return NextResponse.json({ error: 'Upstream timeout' }, { status: 504 });
+  }
 
   if (!res.ok) return NextResponse.json({ error: 'Video not found' }, { status: 404 });
 

--- a/app/api/learn/videos/route.ts
+++ b/app/api/learn/videos/route.ts
@@ -14,7 +14,7 @@ interface YTItem {
 async function getUploadsPlaylistId(apiKey: string): Promise<string> {
   const res = await fetch(
     `https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=${IBM_CHANNEL_ID}&key=${apiKey}`,
-    { next: { revalidate: 86400 } }, // 24h — playlist ID never changes
+    { next: { revalidate: 86400 }, signal: AbortSignal.timeout(8000) }, // 24h cache — playlist ID never changes
   );
   const data = await res.json();
   return data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads ?? '';
@@ -29,7 +29,7 @@ async function fetchVideos(apiKey: string, playlistId: string, pageToken?: strin
   });
   if (pageToken) params.set('pageToken', pageToken);
 
-  const res  = await fetch(`https://www.googleapis.com/youtube/v3/playlistItems?${params}`, { next: { revalidate: 3600 } });
+  const res  = await fetch(`https://www.googleapis.com/youtube/v3/playlistItems?${params}`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(8000) });
   const data = await res.json();
 
   const videos: YTItem[] = (data.items ?? []).map((item: {

--- a/app/interview-prep/loading.tsx
+++ b/app/interview-prep/loading.tsx
@@ -1,0 +1,13 @@
+export default function InterviewPrepLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '45%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem' }}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} style={{ height: '36px', width: '120px', background: 'var(--parchment)', borderRadius: 18, opacity: 0.5 }} />
+        ))}
+      </div>
+      <div style={{ height: '320px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.6 }} />
+    </div>
+  );
+}

--- a/app/learn/loading.tsx
+++ b/app/learn/loading.tsx
@@ -1,0 +1,12 @@
+export default function LearnLoading() {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '50%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '1rem' }}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} style={{ height: '180px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.7 }} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/resume/loading.tsx
+++ b/app/resume/loading.tsx
@@ -1,0 +1,9 @@
+export default function ResumeLoading() {
+  return (
+    <div style={{ maxWidth: '760px', margin: '0 auto', padding: '2rem 1.5rem' }}>
+      <div style={{ height: '2.2rem', width: '55%', background: 'var(--parchment)', borderRadius: 8, marginBottom: '1.5rem', opacity: 0.5 }} />
+      <div style={{ height: '180px', background: 'var(--warm-white)', border: '1px dashed var(--parchment)', borderRadius: 14, marginBottom: '1.25rem', opacity: 0.7 }} />
+      <div style={{ height: '320px', background: 'var(--warm-white)', border: '1px solid var(--parchment)', borderRadius: 14, opacity: 0.6 }} />
+    </div>
+  );
+}

--- a/supabase/032_error_logs.sql
+++ b/supabase/032_error_logs.sql
@@ -1,0 +1,26 @@
+-- Server-side error log sink for `app/api/log-error/route.ts`.
+-- Pairs with Sentry — Sentry handles alerting, this table gives the admin
+-- panel a cheap queryable history without pulling from the Sentry API.
+-- Inserts come only from the service-role client; RLS denies all direct access.
+
+CREATE TABLE IF NOT EXISTS public.error_logs (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  message    text        NOT NULL,
+  digest     text,
+  url        text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.error_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "No direct access to error_logs"
+  ON public.error_logs
+  FOR ALL
+  USING (false);
+
+CREATE INDEX IF NOT EXISTS error_logs_created_at_idx
+  ON public.error_logs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS error_logs_digest_idx
+  ON public.error_logs (digest)
+  WHERE digest IS NOT NULL;

--- a/supabase/033_index_post_comments_user.sql
+++ b/supabase/033_index_post_comments_user.sql
@@ -1,0 +1,10 @@
+-- Speed up comment-ownership lookups in `app/api/comments/[id]/route.ts`
+-- (DELETE/PATCH filter by user_id to enforce ownership before mutating).
+-- Existing indexes cover (post_slug, created_at) and (parent_id) but not
+-- (user_id), so the auth check is a sequential scan as the table grows.
+--
+-- video_progress already covers (user_id, video_id) via the UNIQUE
+-- constraint in migration 006, so no separate index is needed there.
+
+CREATE INDEX IF NOT EXISTS post_comments_user_idx
+  ON public.post_comments (user_id);


### PR DESCRIPTION
## Summary

Rebased replacement for #221 (which was 90 commits behind main and conflict-marked). Drops 4 of 10 commits as redundant against upstream work that landed during the original PR window, keeps 6 unique fixes + 1 test mock fix.

## Commits (8 total)

**Migrations** — already applied to prod via Supabase MCP:
- `feat(db): add error_logs migration` — `supabase/032_error_logs.sql`
- `perf(db): index post_comments(user_id)` — `supabase/033_index_post_comments_user.sql`

**Security**
- `fix(security): rate-limit /api/jobs GET` — 120/hr/IP. Public endpoint aggregating 5+ paid APIs.

**Reliability**
- `fix(reliability): timeouts + stream error handlers on AI/YouTube routes` — `AbortSignal.timeout(8000)` on `learn/videos` + `learn/channel-videos`; 45s/30s on `cover-letter` + `interview/chat` stream creates; `try/catch` inside `start(controller)` so SDK errors surface as `controller.error()`. Plus per-message `.slice(0, 5000)` cap in `interview/chat`.
- `fix(reliability): timeout video-meta RapidAPI fetch` — `AbortSignal.timeout(8000)` + 504 on timeout. Rate-limit was already shipped via `186a92f`.
- `fix(reliability): order dashboard/summary applications by recency` — `.limit(500)` is now deterministic (oldest dropped, not arbitrary).

**UX**
- `ux: error.tsx + loading.tsx for missing segments` — admin/analytics, admin/job-listings, learn, resume, interview-prep.

**Tests**
- `test(dashboard-summary): mock .order()` — chain mock needed to match the new route.

## Dropped as redundant against upstream

| Original commit | Replaced by |
|---|---|
| `refactor(contact): use DB-backed rate limit` | already shipped upstream (`app/api/contact/route.ts` already uses `checkRateLimit`) |
| `fix(security): rate-limit + timeout learn/video-meta cache miss` (rate-limit half) | `186a92f` (timeout half kept as separate v2 commit) |
| `fix(validation): YouTube videoId regex in learn/progress` | already shipped upstream (route has identical regex + extra hardening) |
| `chore(deps): npm audit fix` | main already 0-vuln; lockfile no-op |

## Test plan
- [x] `npm run check` clean (audit 0, content validate, next build) — `EXIT_FINAL:0`
- [x] `vitest run` clean on the 7 changed-route test files (93/93 pass)
- [ ] Prod smoke after merge:
  - [ ] `GET /api/jobs?tab=au` 121× → 429 on 121st
  - [ ] `error_logs` row appears after a `Sentry.captureMessage` smoke
  - [ ] admin/analytics + admin/job-listings render skeleton then content (or error page on failure)

## Replaces
Closes by replacement: #221