### PR TITLE
chore(ci): bump checkout/setup-node v4→v5 (Node 24 deadline)

### DIFF
--- a/.github/workflows/autonomous-loop.yml
+++ b/.github/workflows/autonomous-loop.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -124,7 +124,7 @@ jobs:
           git config user.name "Gradland Autonomous Agent"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: |
           steps.quota_guard.outputs.skip == 'false' &&
           steps.pr_guard.outputs.skip == 'false' &&

--- a/.github/workflows/claude-analyst.yml
+++ b/.github/workflows/claude-analyst.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           gh auth status 2>&1 || true  # GH_TOKEN env var handles auth automatically
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: steps.guard.outputs.skip == 'false'
         with:
           node-version: 22

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 75
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
           git config user.name  "Gradland PR Loop"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -21,7 +21,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/copilot-daily.yml
+++ b/.github/workflows/copilot-daily.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Guard — skip if already ran today
         id: guard

--- a/.github/workflows/copilot-fallback.yml
+++ b/.github/workflows/copilot-fallback.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/daily-career-edge.yml
+++ b/.github/workflows/daily-career-edge.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: steps.guard.outputs.skip == 'false'
         with:
           node-version: '22'

--- a/.github/workflows/daily-claude-news.yml
+++ b/.github/workflows/daily-claude-news.yml
@@ -22,12 +22,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/daily-claude-skill.yml
+++ b/.github/workflows/daily-claude-skill.yml
@@ -25,12 +25,12 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/daily-diagrams.yml
+++ b/.github/workflows/daily-diagrams.yml
@@ -24,12 +24,12 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/daily-posts.yml
+++ b/.github/workflows/daily-posts.yml
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -70,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -108,11 +108,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -147,11 +147,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -74,11 +74,11 @@ jobs:
     if: github.event_name != 'pull_request'   # never deploy from a PR — only from main
     environment: Production  # pauses here — Sheng-wei-Tsai must click Approve in GitHub
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/idle-posts.yml
+++ b/.github/workflows/idle-posts.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.guard.outputs.skip == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/phone-task.yml
+++ b/.github/workflows/phone-task.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Works for both triggers — falls back to main if base_branch not provided
           ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.base_branch || inputs.base_branch || 'main' }}
@@ -88,7 +88,7 @@ jobs:
             echo "tg_msg="                       >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/scrape-jobs.yml
+++ b/.github/workflows/scrape-jobs.yml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 30    # Apify actors can take up to 10 min each
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_PRICE_ID=                     # recurring price ID for the Pro plan
 
 # App
-NEXT_PUBLIC_APP_URL=https://yourapp.vercel.app
+NEXT_PUBLIC_APP_URL=https://gradland.au   # production canonical URL (localhost for dev)
 ```
 
 ### Apply Database Migrations


### PR DESCRIPTION
## Why
`actions/checkout@v4` + `actions/setup-node@v4` run on **Node 20**. GitHub force-migrates these to Node 24 on **2026-06-02** (days away) and removes Node 20 on 2026-09-16. Every run currently logs the deprecation warning.

## Change
- Bump `actions/checkout@v4 → @v5` (20 refs) and `actions/setup-node@v4 → @v5` (16 refs) across all 16 workflow files. No other actions used v4.
- README `.env` example: `NEXT_PUBLIC_APP_URL` placeholder `yourapp.vercel.app` → real prod domain `https://gradland.au`.

Pure version-tag bump — no logic/config changes. The `Security & Build Check` job on this PR exercises the bumped `deploy.yml` on real CI.

Stacks alongside #252 (rolldown CI fix); independent, either can merge first.