### PR TITLE
security: deploy gate hardening — make the gate actually block production

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+# Static application security testing (SAST) — the "security-review" gate.
+# Runs on PRs to main and a weekly schedule. Once it has a baseline run on main,
+# make the "CodeQL" check Required in branch protection (see
+# scripts/setup-branch-protection.sh) so no code merges with a new alert.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 3 * * 1'   # Mondays 03:27 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write   # upload alerts to the Security tab
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # 'security-extended' adds more rules than the default; drop to
+          # 'security-and-quality' if it gets too noisy.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,18 @@
 name: Deploy to Vercel
 
+# Quality + security gate. Vercel's native Git integration deploys main on its
+# own; this workflow is the gate that branch protection makes REQUIRED, so no
+# code merges to main (and therefore deploys) without passing it. The old
+# `deploy` job that ran `vercel --prod` was redundant with Vercel's native
+# deploy and has been removed (see docs/DEPLOY_HARDENING.md).
+
 on:
-  # Triggered by a real user push to main
+  # Real user push to main (GITHUB_TOKEN bot pushes don't fire this — by design;
+  # bot changes go through PRs once branch protection is on).
   push:
     branches: [main]
-  # PRs to main — bot post branches need the check to pass before auto-merge
+  # PRs to main — the required check that auto-merge waits on.
   pull_request:
-    branches: [main]
-  # Triggered after the daily-posts bot pushes (GITHUB_TOKEN pushes don't
-  # fire the `push` event above, so we listen for the workflow completing)
-  workflow_run:
-    workflows: ["Daily Posts"]
-    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -20,15 +21,10 @@ permissions:
   pull-requests: read
 
 jobs:
-  # ── Quality gate — must pass before Vercel deploys ──────────────────────────
+  # ── Quality gate — required by branch protection before merge ───────────────
   check:
     name: Security & Build Check
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v5
 
@@ -65,29 +61,3 @@ jobs:
           NEXT_PUBLIC_APP_URL: https://gradland.au
           NEXT_PUBLIC_LOGO_DEV_TOKEN: ${{ secrets.NEXT_PUBLIC_LOGO_DEV_TOKEN }}
         run: npm run build
-
-  # ── Deploy — check passes + owner approves in GitHub UI ─────────────────────
-  deploy:
-    name: Deploy to Vercel
-    runs-on: ubuntu-latest
-    needs: check          # hard dependency — deploy never runs if check fails
-    if: github.event_name != 'pull_request'   # never deploy from a PR — only from main
-    environment: Production  # pauses here — Sheng-wei-Tsai must click Approve in GitHub
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: main
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-
-      - name: Deploy to Vercel
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: npx vercel --prod --token "$VERCEL_TOKEN" --yes

--- a/TODO.md
+++ b/TODO.md
@@ -182,6 +182,16 @@
 
 ## 🔴 Priority 1 — Retention Engine
 
+### [security] Deploy gate hardening — make the quality/security gate actually block production
+**Why:** Root-cause audit found the gate was decorative: `main` had no branch protection / no required checks, everything direct-pushed to main, and Vercel native auto-deploys main on every push regardless of the Actions `check` job. So vulnerable deps (e.g. the esbuild RCE), broken builds, or unreviewed AI-agent code shipped to gradland.au ungated. Deeper root cause: bots use `GITHUB_TOKEN`, which GitHub blocks from triggering checks — so branch protection alone would stall the pipeline; the fix needs a GitHub App.
+- [x] 2026-06-13 Shared `commitAndPublish` helper (`scripts/lib/git-publish.ts`) — `PUBLISH_MODE=direct` (default, unchanged) vs `pr` (branch + squash auto-merge). Refactored 7 content scripts (fetch-ai-news, run-digest, run-post, run-githot, fetch-visa-news, fetch-claude-news, fetch-claude-skill) onto it — behaviour-identical until activated
+- [x] 2026-06-13 CodeQL SAST workflow (`.github/workflows/codeql.yml`) — the security-review gate
+- [x] 2026-06-13 `scripts/setup-branch-protection.sh` — requires `Security & Build Check` + `CodeQL`, forces PRs (0 required reviews), no force-push
+- [x] 2026-06-13 `deploy.yml` cleanup — removed redundant `vercel --prod` deploy job + `workflow_run` trigger (Vercel native deploys; cleared perpetual "waiting" runs)
+- [x] 2026-06-13 `docs/DEPLOY_HARDENING.md` runbook — GitHub App creation, workflow wiring template, rollout order, rollback
+- [ ] **ACTIVATION (owner):** create the `gradland-ci-bot` GitHub App + secrets `BOT_APP_ID`/`BOT_APP_PRIVATE_KEY`; wire content + code-bot workflows per runbook; `gh variable set PUBLISH_MODE pr`; run `setup-branch-protection.sh`. See `docs/DEPLOY_HARDENING.md`
+- **Effort:** M (done: helper + refactor + CI + runbook). Activation is owner-side (App creation can't be automated)
+
 ### Job Source Categories + Application Kit — multi-platform job discovery
 **Why:** Users want to see where each job lives (Seek / Indeed / official career sites / Adzuna) and filter by platform, then jump out to apply. Paid users get an AI "Application Kit" customised per job + company. Literal auto-apply was considered and dropped (ToS violations on every platform, account-ban risk for users).
 - [x] 2026-06-12 Source-group filter chips on `/jobs` with live counts — groups: Seek, Indeed, LinkedIn (via JSearch/Google Jobs `publisher`), Adzuna, Official career sites (Greenhouse/Lever/Workday/Ashby/Workable/etc.), Government (APS + state boards), Other boards (Jora/ACS/80kh/Remotive/Jobicy). Files: `lib/jobs-sources.ts` (`jobSourceGroup` + group labels/order), `app/jobs/page.tsx` (platform chip row, now visible on AU tab; selecting a group switches sections view to flat filtered list)

--- a/docs/DEPLOY_HARDENING.md
+++ b/docs/DEPLOY_HARDENING.md
@@ -1,0 +1,133 @@
+# Deploy Gate Hardening — Runbook
+
+Make the security/quality gate actually block production, so no vulnerable
+dependency, failing build, or unreviewed code can reach gradland.au.
+
+## The problem (what was true before this work)
+
+- `main` had **no branch protection** and **no required status checks** (verified: the API returned *"Required status checks not enabled"*).
+- Everyone — you and the bots — **pushed directly to `main`**.
+- Vercel's **native Git integration auto-deploys `main`** on every push (`vercel.json` `ignoreCommand` builds main unconditionally), *independently* of GitHub Actions.
+- The `deploy.yml` `check` job ran **after** the push, and its `deploy` job waited for a manual approval nobody clicked.
+
+**Net effect:** the gate was decorative. The esbuild RCE advisory that shipped is the proof — it reached `main` and would deploy regardless of the check.
+
+### The root cause that shapes the fix
+
+The bots authenticate with the default **`GITHUB_TOKEN`**, which GitHub deliberately blocks from triggering other workflows (anti-recursion). So bot-created PRs/pushes **never trigger the `check`**. That's why simply turning on branch protection isn't enough — the required check would never run on bot changes and the daily pipeline would stall. The fix needs a credential that *can* trigger checks: a **GitHub App**.
+
+## End-state architecture
+
+```
+content/code change ──▶ PR (authored via GitHub App token)
+                          │
+                          ▼
+            Required checks run:  Security & Build Check  +  CodeQL
+                          │  (branch protection blocks merge until green)
+                          ▼
+                    squash auto-merge ──▶ main ──▶ Vercel native deploy
+```
+
+- Nothing reaches `main` (the deployed branch) without passing the gate.
+- Vercel keeps doing what it's good at (atomic deploys, instant rollback).
+- The code bots (`claude-pr-loop`, `autonomous-loop`, `phone-task`) already use PR branches; they just need the App token so their PRs trigger the check.
+- The content bots publish via auto-merge PRs through the shared `commitAndPublish` helper.
+
+## What this PR already contains (inert until you activate)
+
+Merging this changes **nothing** about live behaviour — it's safe to merge anytime:
+
+| File | What it does |
+|------|--------------|
+| `scripts/lib/git-publish.ts` | Shared `commitAndPublish({add, message})`. Defaults to `PUBLISH_MODE=direct` (current behaviour). `PUBLISH_MODE=pr` switches to branch + auto-merge PR. |
+| 7 content scripts | Refactored to call `commitAndPublish` instead of inlining `git push origin main`. Behaviour identical until the flag flips. |
+| `.github/workflows/codeql.yml` | CodeQL SAST. Runs on PRs/weekly. Advisory until made a required check. |
+| `.github/workflows/deploy.yml` | Removed the redundant `vercel --prod` deploy job + `workflow_run` trigger (Vercel native already deploys; this just clears the perpetual "waiting" runs). The `check` job is unchanged. |
+| `scripts/setup-branch-protection.sh` | One-shot script to enable protection requiring both checks. **Not run automatically.** |
+| `docs/DEPLOY_HARDENING.md` | This runbook. |
+
+## Activation — do these in order
+
+> Do **not** enable branch protection (step 4) before the App is wired and a bot PR has produced a green check (step 3). Out-of-order = stalled pipeline.
+
+### 1. Create the GitHub App (you — ~15 min, only you can)
+
+1. **Settings → Developer settings → GitHub Apps → New GitHub App.**
+   - Name: `gradland-ci-bot` (or anything).
+   - Homepage URL: your repo URL. Uncheck **Webhook → Active**.
+   - **Repository permissions:** `Contents: Read and write`, `Pull requests: Read and write`. Nothing else.
+   - "Only on this account."
+2. **Create**, then note the **App ID**. Generate a **private key** (downloads a `.pem`).
+3. **Install App** → install on `Sheng-wei-Tsai/gradland` only.
+4. Add two repo secrets (**Settings → Secrets and variables → Actions → Secrets**):
+   - `BOT_APP_ID` = the App ID
+   - `BOT_APP_PRIVATE_KEY` = the full contents of the `.pem`
+
+A GitHub App is the secure choice: scoped to this one repo, issues short-lived tokens, revocable, and doesn't impersonate you. Keep the `.pem` out of the repo.
+
+### 2. Wire the workflows to use the App token in PR mode
+
+For **each content workflow** (`daily-posts.yml`, `daily-claude-news.yml`, `daily-claude-skill.yml`, `daily-diagrams.yml`, `daily-career-edge.yml`, `idle-posts.yml`), and in **each job that runs a content script**, add a token-minting step and pass it to the script step. Pattern:
+
+```yaml
+      # add BEFORE the step that runs the content script
+      - name: Mint bot token (PR mode only)
+        if: ${{ vars.PUBLISH_MODE == 'pr' }}
+        id: bot
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: <existing content step>
+        env:
+          PUBLISH_MODE: ${{ vars.PUBLISH_MODE || 'direct' }}
+          # App token in PR mode (triggers the check); GITHUB_TOKEN otherwise
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          npx tsx scripts/fetch-ai-news.ts   # ← the existing script call
+```
+
+The `if:` + `|| 'direct'` / `|| secrets.GITHUB_TOKEN` fallbacks mean this is a **no-op until the `PUBLISH_MODE` repo variable is set to `pr`** — so you can merge the workflow edits safely and flip the switch later.
+
+For the **code bots** (`claude-pr-loop.yml`, `autonomous-loop.yml`, `phone-task.yml`): they already open PRs, but with `secrets.GITHUB_TOKEN`, so their PRs won't trigger the required check. Swap the token used for `gh pr create` / `git push` / `gh pr merge` to the App token (same `actions/create-github-app-token` step, then `GH_TOKEN: ${{ steps.bot.outputs.token }}`). Otherwise their PRs will stall under branch protection.
+
+### 3. Flip the switch and verify
+
+```bash
+# enable repo-level auto-merge
+gh api -X PATCH repos/Sheng-wei-Tsai/gradland -f allow_auto_merge=true
+# turn on PR mode for the bots
+gh variable set PUBLISH_MODE --body pr
+```
+
+Manually run one content workflow (`gh workflow run "Daily Posts"`). Confirm: it opens a PR authored by the App, the `Security & Build Check` + `CodeQL` checks run on it, and it auto-merges when green. If the checks don't appear on the PR, the App token isn't being used — recheck step 2.
+
+### 4. Enable branch protection
+
+```bash
+sh scripts/setup-branch-protection.sh
+# or, to gate yourself too (most secure):
+ENFORCE_ADMINS=true sh scripts/setup-branch-protection.sh
+```
+
+Verify the context names match real check-run names:
+
+```bash
+gh api repos/Sheng-wei-Tsai/gradland/commits/main/check-runs --jq '.check_runs[].name'
+```
+
+If `CodeQL`'s check name differs, edit `CONTEXT_CODEQL` in the script and re-run.
+
+## Rollback
+
+- **Disable PR mode:** `gh variable set PUBLISH_MODE --body direct` (bots resume direct-push).
+- **Remove protection:** `gh api -X DELETE repos/Sheng-wei-Tsai/gradland/branches/main/protection`.
+- The script refactor is behaviour-identical in `direct` mode, so reverting the flag fully restores the old pipeline.
+
+## Residual notes
+
+- This gate blocks **vulnerable deps, broken builds, failing tests, and CodeQL alerts**. Application-logic security (RLS, rate limiting, auth, input validation) is governed by `AGENTS.md` §5 and code review — not this gate. Consider requiring 1 human review on `app/api/**` and `lib/` paths via CODEOWNERS for the highest-risk code.
+- The App private key is now your most sensitive CI secret. If it leaks, revoke it in the App settings and generate a new one.

--- a/scripts/fetch-ai-news.ts
+++ b/scripts/fetch-ai-news.ts
@@ -8,6 +8,7 @@ import { claudeMessage, ClaudeQuotaError } from './llm-claude';
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 
 
 const parser  = new Parser({ timeout: 20000 });
@@ -410,34 +411,13 @@ async function main() {
 
   console.log(`\nWrote ${written.length} file${written.length !== 1 ? 's' : ''} to content/ai-news/`);
 
-  // 4. Commit and push
-  console.log('\nPushing to GitHub...');
-  try {
-    for (const fp of written) {
-      execSync('git add ' + fp, { stdio: 'inherit' });
-    }
-    const dateStr = formatDate(new Date());
-    execSync(`git commit -m "ai-news: ${written.length} new article${written.length !== 1 ? 's' : ''} ${dateStr}"`, { stdio: 'inherit' });
-
-    const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-    let pushed = false;
-    for (let attempt = 1; attempt <= 3 && !pushed; attempt++) {
-      try {
-        if (attempt > 1) {
-          await sleep(10000 * attempt);
-          execSync('git pull --rebase origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        }
-        execSync('git push origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        pushed = true;
-      } catch {
-        if (attempt === 3) throw new Error('push failed after 3 attempts');
-        console.warn(`Push attempt ${attempt} failed, retrying...`);
-      }
-    }
-    console.log('Deployed — Vercel is building now');
-  } catch (err) {
-    console.warn('Git push failed:', (err as Error).message);
-  }
+  // 4. Commit and publish (direct to main, or via auto-merge PR under branch protection)
+  console.log('\nPublishing to GitHub...');
+  const dateStr = formatDate(new Date());
+  await commitAndPublish({
+    add: written,
+    message: `ai-news: ${written.length} new article${written.length !== 1 ? 's' : ''} ${dateStr}`,
+  });
 }
 
 main().catch(err => {

--- a/scripts/fetch-claude-news.ts
+++ b/scripts/fetch-claude-news.ts
@@ -19,6 +19,7 @@ else dotenv.config();
 import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 import Parser from 'rss-parser';
 import { claudeJSON, ClaudeQuotaError } from './llm-claude';
 
@@ -339,9 +340,10 @@ async function main() {
   console.log(`\nWrote ${written} new item(s).`);
 
   if (DRY_RUN) { console.log('Dry run — skipping git commit.'); return; }
-  execFileSync('git', ['add', 'content/claude-code/', 'data/claude-docs-seen.json'], { stdio: 'inherit' });
-  execFileSync('git', ['commit', '-m', `claude-code: ${written} news item${written === 1 ? '' : 's'} ${formatDate(new Date())}`], { stdio: 'inherit' });
-  execFileSync('git', ['push', 'origin', 'main'], { stdio: 'inherit' });
+  await commitAndPublish({
+    add: ['content/claude-code/', 'data/claude-docs-seen.json'],
+    message: `claude-code: ${written} news item${written === 1 ? '' : 's'} ${formatDate(new Date())}`,
+  });
 }
 
 main().catch(err => {

--- a/scripts/fetch-claude-skill.ts
+++ b/scripts/fetch-claude-skill.ts
@@ -19,6 +19,7 @@ else dotenv.config();
 
 import path from 'path';
 import { execFileSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 import { claudeJSON, claudeMessage, ClaudeQuotaError } from './llm-claude';
 
 const OUT_DIR    = path.join(process.cwd(), 'content', 'claude-skills');
@@ -253,10 +254,10 @@ async function run() {
     return;
   }
 
-  execFileSync('git', ['add', 'content/claude-skills/'], { stdio: 'inherit' });
-  execFileSync('git', ['commit', '-m', `claude-skills: daily lesson ${today} — ${topic.title}`], { stdio: 'inherit' });
-  execFileSync('git', ['push', 'origin', 'main'], { stdio: 'inherit' });
-  console.log('Pushed.');
+  await commitAndPublish({
+    add: ['content/claude-skills/'],
+    message: `claude-skills: daily lesson ${today} — ${topic.title}`,
+  });
 }
 
 run().catch(err => {

--- a/scripts/fetch-visa-news.ts
+++ b/scripts/fetch-visa-news.ts
@@ -7,6 +7,7 @@ import { claudeMessage, ClaudeQuotaError } from './llm-claude';
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 
 
 const parser  = new Parser({ timeout: 20000 });
@@ -319,34 +320,13 @@ async function main() {
 
   console.log(`\nWrote ${written.length} file${written.length !== 1 ? 's' : ''} to content/visa-news/`);
 
-  // 4. Commit and push
-  console.log('\nPushing to GitHub...');
-  try {
-    for (const fp of written) {
-      execSync('git add ' + fp, { stdio: 'inherit' });
-    }
-    const dateStr = formatDate(new Date());
-    execSync(`git commit -m "visa-news: ${written.length} new article${written.length !== 1 ? 's' : ''} ${dateStr}"`, { stdio: 'inherit' });
-
-    const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-    let pushed = false;
-    for (let attempt = 1; attempt <= 3 && !pushed; attempt++) {
-      try {
-        if (attempt > 1) {
-          await sleep(10000 * attempt);
-          execSync('git pull --rebase origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        }
-        execSync('git push origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        pushed = true;
-      } catch {
-        if (attempt === 3) throw new Error('push failed after 3 attempts');
-        console.warn(`Push attempt ${attempt} failed, retrying...`);
-      }
-    }
-    console.log('Deployed — Vercel is building now');
-  } catch (err) {
-    console.warn('Git push failed:', (err as Error).message);
-  }
+  // 4. Commit and publish (direct to main, or via auto-merge PR under branch protection)
+  console.log('\nPublishing to GitHub...');
+  const dateStr = formatDate(new Date());
+  await commitAndPublish({
+    add: written,
+    message: `visa-news: ${written.length} new article${written.length !== 1 ? 's' : ''} ${dateStr}`,
+  });
 }
 
 main().catch(err => {

--- a/scripts/lib/git-publish.ts
+++ b/scripts/lib/git-publish.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared commit/publish helper for the daily content bots.
+ *
+ * Two modes, selected by the PUBLISH_MODE env var:
+ *
+ *   - 'direct' (default): commit + push straight to main, with the existing
+ *     3-attempt rebase retry. This is the legacy behaviour — safe for local
+ *     runs and unchanged until branch protection is switched on.
+ *
+ *   - 'pr': commit on a throwaway branch, push it, open a PR, and enable
+ *     squash auto-merge. Under branch protection (required `check` status),
+ *     GitHub holds the merge until the gate passes — so no content reaches
+ *     main, and therefore production, without passing audit/test/build.
+ *     Requires a credential in GH_TOKEN that can trigger workflows (a GitHub
+ *     App installation token — NOT the default GITHUB_TOKEN, which GitHub
+ *     blocks from triggering the required check).
+ *
+ * See docs/DEPLOY_HARDENING.md for the rollout order.
+ */
+import { execFileSync } from 'node:child_process';
+
+const GIT_ENV = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
+const MODE = process.env.PUBLISH_MODE ?? 'direct';
+
+export interface PublishOptions {
+  /** Paths or directories to `git add` (e.g. ['content/ai-news/foo.md'] or ['content/claude-code/']). */
+  add: string[];
+  /** Commit message — also used as the PR title in 'pr' mode. The text before the first ':' becomes the branch prefix. */
+  message: string;
+  /** Optional PR body in 'pr' mode (defaults to the commit message). */
+  prBody?: string;
+}
+
+function git(args: string[], opts: { allowFail?: boolean } = {}): boolean {
+  try {
+    execFileSync('git', args, { stdio: 'inherit', env: GIT_ENV, timeout: 60_000 });
+    return true;
+  } catch (err) {
+    if (opts.allowFail) return false;
+    throw err;
+  }
+}
+
+function hasStagedChanges(): boolean {
+  const out = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' });
+  return out.trim().length > 0;
+}
+
+function branchName(message: string): string {
+  const prefix = (message.split(':')[0] || 'bot')
+    .trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 24) || 'bot';
+  const uniq = process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? '1'}`
+    : String(Date.now());
+  return `bot/${prefix}-${uniq}`;
+}
+
+/** Commit the given paths and publish them — to main directly, or via an auto-merge PR. */
+export async function commitAndPublish({ add, message, prBody }: PublishOptions): Promise<void> {
+  for (const p of add) git(['add', p]);
+  if (!hasStagedChanges()) {
+    console.log('Nothing to commit — skipping publish.');
+    return;
+  }
+
+  if (MODE === 'pr') {
+    await publishViaPR(message, prBody);
+  } else {
+    git(['commit', '-m', message]);
+    await pushMainWithRetry();
+  }
+}
+
+async function publishViaPR(message: string, prBody?: string): Promise<void> {
+  const branch = branchName(message);
+  git(['checkout', '-b', branch]);
+  git(['commit', '-m', message]);
+  git(['push', '-u', 'origin', branch]);
+  // `gh` reads the credential from GH_TOKEN — must be a GitHub App installation
+  // token so the PR triggers the required `check`. The default GITHUB_TOKEN will not.
+  execFileSync('gh', ['pr', 'create', '--base', 'main', '--head', branch,
+    '--title', message, '--body', prBody ?? message], { stdio: 'inherit', env: process.env });
+  execFileSync('gh', ['pr', 'merge', branch, '--auto', '--squash', '--delete-branch'],
+    { stdio: 'inherit', env: process.env });
+  console.log(`Opened PR from ${branch} with squash auto-merge — merges once the gate passes.`);
+}
+
+async function pushMainWithRetry(): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    if (attempt > 1) {
+      await new Promise(r => setTimeout(r, 10_000 * attempt));
+      git(['pull', '--rebase', 'origin', 'main'], { allowFail: true });
+    }
+    if (git(['push', 'origin', 'main'], { allowFail: attempt < 3 })) {
+      console.log('Pushed to main — Vercel is building.');
+      return;
+    }
+    console.warn(`Push attempt ${attempt} failed, retrying...`);
+  }
+}

--- a/scripts/run-digest.ts
+++ b/scripts/run-digest.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 import { fetchAll } from './fetch-digest';
 import { filterItems } from './filter';
 import { summarizeAll } from './summarize';
@@ -39,32 +40,10 @@ async function main() {
   // 4. Write digest post (.md so Obsidian can open it)
   const filePath = writeDigestPost(entries);
 
-  // 5. Commit + push so Vercel deploys automatically
+  // 5. Commit + publish (direct to main, or via auto-merge PR under branch protection)
   const dateStr = new Date().toISOString().split('T')[0];
-  console.log('\n\u{1F4E4} Pushing to GitHub...');
-  try {
-    execSync(`git add "${filePath}"`, { stdio: 'inherit' });
-    execSync(`git commit -m "digest: AI Research Digest ${dateStr}"`, { stdio: 'inherit' });
-    // Retry push with rebase to handle parallel job conflicts
-    const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-    let pushed = false;
-    for (let attempt = 1; attempt <= 3 && !pushed; attempt++) {
-      try {
-        if (attempt > 1) {
-          await new Promise(r => setTimeout(r, 10000 * attempt));
-          execSync('git pull --rebase origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        }
-        execSync('git push origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        pushed = true;
-      } catch (pushErr) {
-        if (attempt === 3) throw pushErr;
-        console.warn(`Push attempt ${attempt} failed, retrying...`);
-      }
-    }
-    console.log('Deployed — Vercel is building now');
-  } catch (err) {
-    console.warn('Git push failed (maybe nothing changed):', (err as Error).message);
-  }
+  console.log('\n\u{1F4E4} Publishing to GitHub...');
+  await commitAndPublish({ add: [filePath], message: `digest: AI Research Digest ${dateStr}` });
 
   console.log('\n✅ Digest pipeline complete!');
 }

--- a/scripts/run-githot.ts
+++ b/scripts/run-githot.ts
@@ -4,6 +4,7 @@ import { claudeMessage, ClaudeQuotaError } from './llm-claude';
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 
 
 
@@ -262,30 +263,9 @@ async function main() {
   fs.writeFileSync(filePath, writePost(analyses), 'utf8');
   console.log(`\n📝 Post written → content/githot/${dateStr}.md`);
 
-  console.log('\n📤 Pushing to GitHub...');
-  try {
-    execSync(`git add "${filePath}"`, { stdio: 'inherit' });
-    execSync(`git commit -m "githot: GitHub Hot ${dateStr}"`, { stdio: 'inherit' });
-    // Retry push with rebase to handle parallel job conflicts
-    const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-    let pushed = false;
-    for (let attempt = 1; attempt <= 3 && !pushed; attempt++) {
-      try {
-        if (attempt > 1) {
-          await sleep(10000 * attempt);
-          execSync('git pull --rebase origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        }
-        execSync('git push origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        pushed = true;
-      } catch (pushErr) {
-        if (attempt === 3) throw pushErr;
-        console.warn(`⚠️  Push attempt ${attempt} failed, retrying...`);
-      }
-    }
-    console.log('✅ Deployed — Vercel is building now');
-  } catch (err) {
-    console.warn('⚠️  Git push failed:', (err as Error).message);
-  }
+  // Commit + publish (direct to main, or via auto-merge PR under branch protection)
+  console.log('\n📤 Publishing to GitHub...');
+  await commitAndPublish({ add: [filePath], message: `githot: GitHub Hot ${dateStr}` });
 }
 
 main().catch(err => {

--- a/scripts/run-post.ts
+++ b/scripts/run-post.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
+import { commitAndPublish } from './lib/git-publish';
 
 
 
@@ -239,31 +240,9 @@ ${post.body}
   fs.writeFileSync(filePath, content, 'utf8');
   console.log(`📝 Post written → content/posts/${filename}`);
 
-  // 5. Commit + push → Vercel auto-deploys
-  console.log('\n📤 Pushing to GitHub...');
-  try {
-    execSync(`git add "${filePath}"`, { stdio: 'inherit' });
-    execSync(`git commit -m "post: ${post.title}"`, { stdio: 'inherit' });
-    // Retry push with rebase to handle parallel job conflicts
-    const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-    let pushed = false;
-    for (let attempt = 1; attempt <= 3 && !pushed; attempt++) {
-      try {
-        if (attempt > 1) {
-          await new Promise(r => setTimeout(r, 10000 * attempt));
-          execSync('git pull --rebase origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        }
-        execSync('git push origin main', { stdio: 'inherit', env: gitEnv, timeout: 60000 });
-        pushed = true;
-      } catch (pushErr) {
-        if (attempt === 3) throw pushErr;
-        console.warn(`Push attempt ${attempt} failed, retrying...`);
-      }
-    }
-    console.log('Deployed — Vercel is building now');
-  } catch (err) {
-    console.warn('Git push failed:', (err as Error).message);
-  }
+  // 5. Commit + publish (direct to main, or via auto-merge PR under branch protection)
+  console.log('\n📤 Publishing to GitHub...');
+  await commitAndPublish({ add: [filePath], message: `post: ${post.title}` });
 
   console.log('\n✅ Daily Post pipeline complete!');
 }

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Enable branch protection on main so nothing reaches production ungated.
+#
+# Run this ONLY after the GitHub App is wired and you've confirmed bot PRs
+# trigger the checks (see docs/DEPLOY_HARDENING.md). Enabling it before the
+# bots can produce passing checks will stall the daily content pipeline.
+#
+# Requires: gh CLI authenticated with admin on the repo.
+# Usage:    sh scripts/setup-branch-protection.sh
+#           ENFORCE_ADMINS=true sh scripts/setup-branch-protection.sh   # also gate the owner
+#
+set -euo pipefail
+
+REPO="${REPO:-Sheng-wei-Tsai/gradland}"
+BRANCH="${BRANCH:-main}"
+ENFORCE_ADMINS="${ENFORCE_ADMINS:-false}"   # true = even repo admins must use PRs (most secure)
+
+# Required status-check contexts. These must match the check-run names exactly.
+#   "Security & Build Check" — the job name in deploy.yml
+#   "CodeQL"                  — the CodeQL workflow's check name
+# If a name is wrong the API silently waits forever; verify with:
+#   gh api "repos/$REPO/commits/$BRANCH/check-runs" --jq '.check_runs[].name'
+CONTEXT_BUILD="Security & Build Check"
+CONTEXT_CODEQL="CodeQL"
+
+echo "Enabling branch protection on $REPO@$BRANCH (enforce_admins=$ENFORCE_ADMINS)…"
+
+# required_approving_review_count: 0 forces a PR for every change (no direct
+# pushes) without requiring a human approval — the gate is the checks, not a
+# reviewer. Raise to 1 later if you want mandatory human review on code.
+gh api -X PUT "repos/$REPO/branches/$BRANCH/protection" \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<JSON
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["$CONTEXT_BUILD", "$CONTEXT_CODEQL"]
+  },
+  "enforce_admins": $ENFORCE_ADMINS,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": true
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+
+echo "✅ Branch protection enabled. Verify:"
+echo "   gh api repos/$REPO/branches/$BRANCH/protection --jq '.required_status_checks'"
+echo
+echo "Also enable repo-level auto-merge (one-time):"
+echo "   gh api -X PATCH repos/$REPO -f allow_auto_merge=true"

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -22,7 +22,7 @@ ENFORCE_ADMINS="${ENFORCE_ADMINS:-false}"   # true = even repo admins must use P
 # If a name is wrong the API silently waits forever; verify with:
 #   gh api "repos/$REPO/commits/$BRANCH/check-runs" --jq '.check_runs[].name'
 CONTEXT_BUILD="Security & Build Check"
-CONTEXT_CODEQL="CodeQL"
+CONTEXT_CODEQL="Analyze (javascript-typescript)"   # CodeQL job's check-run name
 
 echo "Enabling branch protection on $REPO@$BRANCH (enforce_admins=$ENFORCE_ADMINS)…"
 


### PR DESCRIPTION
## Why

Root-cause audit found the security/quality gate was **decorative**:
- `main` had no branch protection / no required status checks
- everything direct-pushed to `main`
- Vercel native auto-deploys `main` on every push, regardless of the Actions `check`

So the esbuild RCE advisory (and any vulnerable dep / broken build / unreviewed AI-agent code) shipped to gradland.au **ungated**.

**Deeper root cause:** bots use the default `GITHUB_TOKEN`, which GitHub blocks from triggering workflows — so branch protection *alone* would stall the pipeline. The real fix needs a **GitHub App** so bot PRs trigger the required check.

## What's in this PR (safe to merge — inert until activated)

Merging changes **no live behaviour** (`PUBLISH_MODE` defaults to `direct`):
- `scripts/lib/git-publish.ts` — shared `commitAndPublish` helper (direct vs auto-merge-PR mode)
- 7 content scripts refactored onto it (behaviour-identical until flag flips)
- `.github/workflows/codeql.yml` — CodeQL SAST (the security-review gate)
- `.github/workflows/deploy.yml` — removed the redundant `vercel --prod` job + `workflow_run` trigger (cleared the perpetual "waiting" runs; Vercel native still deploys)
- `scripts/setup-branch-protection.sh` — one-shot protection enabler (not auto-run)
- `docs/DEPLOY_HARDENING.md` — full runbook

## Activation (owner-side, after merge)

Can't be automated — requires creating a GitHub App. Full steps in `docs/DEPLOY_HARDENING.md`:
1. Create `gradland-ci-bot` App + secrets `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY`
2. Wire content + code-bot workflows to mint the App token in PR mode (template in runbook)
3. `gh variable set PUBLISH_MODE pr` + enable auto-merge
4. `sh scripts/setup-branch-protection.sh`

## Verification
- `npm run check` ✅ (lockfile + audit + content + build)
- `npm test` ✅ 1053 passed
- script typecheck ✅